### PR TITLE
Extend num storage

### DIFF
--- a/codegen-luau/runtime/runtime.lua
+++ b/codegen-luau/runtime/runtime.lua
@@ -413,6 +413,8 @@ do
 
 	local reinterpret_f32_i32 = module.reinterpret.f32_i32
 	local reinterpret_f64_i64 = module.reinterpret.f64_i64
+	local reinterpret_i32_f32 = module.reinterpret.i32_f32
+	local reinterpret_i64_f64 = module.reinterpret.i64_f64
 
 	local function load_byte(data, addr)
 		local value = data[math_floor(addr / 4)] or 0
@@ -533,6 +535,16 @@ do
 
 		store_i32(memory, addr, data_1)
 		store_i32(memory, addr + 4, data_2)
+	end
+
+	local store_i64 = store.i64
+
+	function store.f32(memory, addr, value)
+		store_i32(memory, addr, reinterpret_i32_f32(value))
+	end
+
+	function store.f64(memory, addr, value)
+		store_i64(memory, addr, reinterpret_i64_f64(value))
 	end
 
 	function store.string(memory, offset, data, len)

--- a/codegen-luau/runtime/runtime.lua
+++ b/codegen-luau/runtime/runtime.lua
@@ -533,17 +533,17 @@ do
 	local store_i32_n16 = store.i32_n16
 
 	function store.i64_n8(memory, addr, value)
-		local data_1, data_2 = num_into_u32(value)
+		local data_1, _ = num_into_u32(value)
 
 		store_i32_n8(memory, addr, data_1)
 	end
 	function store.i64_n16(memory, addr, value)
-		local data_1, data_2 = num_into_u32(value)
+		local data_1, _ = num_into_u32(value)
 
 		store_i32_n16(memory, addr, data_1)
 	end
 	function store.i64_n32(memory, addr, value)
-		local data_1, data_2 = num_into_u32(value)
+		local data_1, _ = num_into_u32(value)
 
 		store_i32(memory, addr, data_1)
 	end

--- a/codegen-luau/runtime/runtime.lua
+++ b/codegen-luau/runtime/runtime.lua
@@ -537,11 +537,13 @@ do
 
 		store_i32_n8(memory, addr, data_1)
 	end
+
 	function store.i64_n16(memory, addr, value)
 		local data_1, _ = num_into_u32(value)
 
 		store_i32_n16(memory, addr, data_1)
 	end
+
 	function store.i64_n32(memory, addr, value)
 		local data_1, _ = num_into_u32(value)
 

--- a/codegen-luau/runtime/runtime.lua
+++ b/codegen-luau/runtime/runtime.lua
@@ -529,6 +529,24 @@ do
 	end
 
 	local store_i32 = store.i32
+	local store_i32_n8 = store.i32_n8
+	local store_i32_n16 = store.i32_n16
+
+	function store.i64_n8(memory, addr, value)
+		local data_1, data_2 = num_into_u32(value)
+
+		store_i32_n8(memory, addr, data_1)
+	end
+	function store.i64_n16(memory, addr, value)
+		local data_1, data_2 = num_into_u32(value)
+
+		store_i32_n16(memory, addr, data_1)
+	end
+	function store.i64_n32(memory, addr, value)
+		local data_1, data_2 = num_into_u32(value)
+
+		store_i32(memory, addr, data_1)
+	end
 
 	function store.i64(memory, addr, value)
 		local data_1, data_2 = num_into_u32(value)


### PR DESCRIPTION
So far, this contains `store.f32`, `store.f64`, `store.i64_n32`, `store.i64_n16`, and `store.i64_n8` implementations for luau.

I would additionally like to implement all of these `load` variants:
* `load.i32_u16`
* `load.i64_i32`
* `load.i64_i16`
* `load.i64_i8`
* `load.i64_u32`
* `load.i64_u16`
* `load.i64_u8`

This would satisfy the conditions for `address.wast.lua` and `align.wast.lua` to both pass under luau.