### PR TITLE
Add memory.copy/fill

### DIFF
--- a/codegen/luajit/runtime/runtime.lua
+++ b/codegen/luajit/runtime/runtime.lua
@@ -754,6 +754,19 @@ do
 		ffi.copy(start, data, len or #data)
 	end
 
+	function store.copy(memory, dst, src, len)
+		local dst_addr = by_offset(memory.data, dst)
+		local src_addr = by_offset(memory.data, src)
+
+		ffi.copy(dst_addr, src_addr, len)
+	end
+
+	function store.fill(memory, addr, value, len)
+		local start = by_offset(memory.data, addr)
+
+		ffi.fill(start, len, value)
+	end
+
 	local WASM_PAGE_SIZE = 65536
 
 	local function finalizer(memory)

--- a/codegen/luajit/src/backend/statement.rs
+++ b/codegen/luajit/src/backend/statement.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use wasm_ast::node::{
-	Block, Br, BrIf, BrTable, Call, CallIndirect, FuncData, If, LabelType, MemoryGrow, SetGlobal,
+	Block, Br, BrIf, BrTable, Call, CallIndirect, FuncData, If, LabelType, MemoryGrow, MemoryCopy, MemoryFill, SetGlobal,
 	SetLocal, SetTemporary, Statement, StoreAt, Terminator,
 };
 use wasmparser::ValType;
@@ -282,6 +282,32 @@ impl DriverNoContext for MemoryGrow {
 	}
 }
 
+impl DriverNoContext for MemoryCopy {
+	fn write(&self, w: &mut dyn Write) -> Result<()> {
+		let dst = self.dst();
+		let src = self.src();
+
+		write!(w, "store.copy(memory_at_0, {dst}, {src}, ")?;
+		self.size().write(w)?;
+		write!(w, ")")
+
+	}
+}
+
+impl DriverNoContext for MemoryFill {
+	fn write(&self, w: &mut dyn Write) -> Result<()> {
+		let mem = self.mem();
+		let value = self.value();
+		let n = self.n();
+
+		write!(w, "store.fill(memory_at_0, {mem}, ")?;
+		value.write(w)?;
+		write!(w, ", ")?;
+		n.write(w)?;
+		write!(w, ")")
+	}
+}
+
 fn write_stat(stat: &dyn DriverNoContext, mng: &mut Manager, w: &mut dyn Write) -> Result<()> {
 	indentation!(mng, w)?;
 	stat.write(w)?;
@@ -301,6 +327,8 @@ impl Driver for Statement {
 			Self::SetGlobal(s) => write_stat(s, mng, w),
 			Self::StoreAt(s) => write_stat(s, mng, w),
 			Self::MemoryGrow(s) => write_stat(s, mng, w),
+			Self::MemoryCopy(s) => write_stat(s, mng, w),
+			Self::MemoryFill(s) => write_stat(s, mng, w),
 		}
 	}
 }

--- a/codegen/luau/runtime/runtime.lua
+++ b/codegen/luau/runtime/runtime.lua
@@ -927,6 +927,20 @@ do
 		end
 	end
 
+	function store.copy(memory, dst, src, len)
+		for i = 1, len do
+			local v = load_byte(memory, src + i - 1)
+
+			store_byte(memory, dst + i - 1, v)
+		end
+	end
+
+	function store.fill(memory, dst, value, len)
+		for i = 1, len do
+			store_byte(memory, dst + i - 1, value)
+		end
+	end
+
 	function allocator.new(min, max)
 		return { min = min, max = max, data = {} }
 	end

--- a/codegen/luau/src/backend/statement.rs
+++ b/codegen/luau/src/backend/statement.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use wasm_ast::node::{
-	Block, Br, BrIf, BrTable, Call, CallIndirect, FuncData, If, LabelType, MemoryGrow, SetGlobal,
+	Block, Br, BrIf, BrTable, Call, CallIndirect, FuncData, If, LabelType, MemoryGrow, MemoryCopy,MemoryFill, SetGlobal,
 	SetLocal, SetTemporary, Statement, StoreAt, Terminator,
 };
 use wasmparser::ValType;
@@ -301,6 +301,32 @@ impl DriverNoContext for MemoryGrow {
 	}
 }
 
+impl DriverNoContext for MemoryCopy {
+	fn write(&self, w: &mut dyn Write) -> Result<()> {
+		let dst = self.dst();
+		let src = self.src();
+		let size = self.size();
+
+		write!(w, "store.copy(memory_at_0, {dst}, {src}, ")?;
+		size.write(w)?;
+		write!(w, ")")
+	}
+}
+
+impl DriverNoContext for MemoryFill {
+	fn write(&self, w: &mut dyn Write) -> Result<()> {
+		let mem = self.mem();
+		let value = self.value();
+		let n = self.n();
+
+		write!(w, "store.copy(memory_at_0, {mem}, ")?;
+		value.write(w)?;
+		write!(w, ", ")?;
+		n.write(w)?;
+		write!(w, ")")
+	}
+}
+
 fn write_stat(stat: &dyn DriverNoContext, mng: &mut Manager, w: &mut dyn Write) -> Result<()> {
 	indentation!(mng, w)?;
 	stat.write(w)?;
@@ -320,6 +346,8 @@ impl Driver for Statement {
 			Self::SetGlobal(s) => write_stat(s, mng, w),
 			Self::StoreAt(s) => write_stat(s, mng, w),
 			Self::MemoryGrow(s) => write_stat(s, mng, w),
+			Self::MemoryCopy(s) => write_stat(s, mng, w),
+			Self::MemoryFill(s) => write_stat(s, mng, w),
 		}
 	}
 }

--- a/wasm-ast/src/factory.rs
+++ b/wasm-ast/src/factory.rs
@@ -4,7 +4,7 @@ use crate::{
 	module::{read_checked, TypeInfo},
 	node::{
 		BinOp, BinOpType, Block, Br, BrIf, BrTable, Call, CallIndirect, CmpOp, CmpOpType,
-		Expression, FuncData, GetGlobal, GetLocal, If, LabelType, LoadAt, LoadType, MemoryGrow,
+		Expression, FuncData, GetGlobal, GetLocal, If, LabelType, LoadAt, LoadType, MemoryGrow, MemoryCopy, MemoryFill,
 		MemorySize, Select, SetGlobal, SetLocal, Statement, StoreAt, StoreType, Terminator, UnOp,
 		UnOpType, Value,
 	},
@@ -607,6 +607,29 @@ impl<'a> Factory<'a> {
 				});
 
 				self.target.leak_memory_write(memory);
+				self.target.code.push(data);
+			}
+			Operator::MemoryCopy { src, dst }	=> {
+				let size = self.target.stack.pop().into();
+
+				let data = Statement::MemoryCopy(MemoryCopy {
+					dst,
+					src,
+					size,
+				});
+
+				self.target.code.push(data);
+			}
+			Operator::MemoryFill { mem } => {
+				let n = self.target.stack.pop().into();
+				let value = self.target.stack.pop().into();
+
+				let data = Statement::MemoryFill(MemoryFill {
+					mem,
+					n,
+					value,
+				});
+				
 				self.target.code.push(data);
 			}
 			Operator::I32Const { value } => self.target.push_constant(value),

--- a/wasm-ast/src/node.rs
+++ b/wasm-ast/src/node.rs
@@ -1108,6 +1108,48 @@ impl MemoryGrow {
 	}
 }
 
+pub struct MemoryCopy {
+	pub(crate) dst: u32,
+	pub(crate) src: u32,
+	pub(crate) size: Box<Expression>,
+}
+
+impl MemoryCopy {
+	#[must_use]
+	pub fn dst(&self) -> u32 {
+		self.dst
+	}
+	#[must_use]
+	pub fn src(&self) -> u32 {
+		self.src
+	}
+	#[must_use]
+	pub fn size(&self) -> &Expression {
+		&self.size
+	}
+}
+
+pub struct MemoryFill {
+	pub(crate) mem: u32,
+	pub(crate) value: Box<Expression>,
+	pub(crate) n: Box<Expression>,
+}
+
+impl MemoryFill {
+	#[must_use]
+	pub fn mem(&self) -> u32 {
+		self.mem
+	}
+	#[must_use]
+	pub fn value(&self) -> &Expression {
+		&self.value
+	}
+	#[must_use]
+	pub fn n(&self) -> &Expression {
+		&self.n
+	}
+}
+
 pub enum Statement {
 	Block(Block),
 	BrIf(BrIf),
@@ -1119,6 +1161,8 @@ pub enum Statement {
 	SetGlobal(SetGlobal),
 	StoreAt(StoreAt),
 	MemoryGrow(MemoryGrow),
+	MemoryCopy(MemoryCopy),
+	MemoryFill(MemoryFill),
 }
 
 pub struct FuncData {


### PR DESCRIPTION
I don't have much idea of what's going on here, but I think this is a step in the right direction. Please be very vigilant for mistakes as I'm sure they are present. I hope that I can quickly learn and become a net-positive contributor. I started working on this because of [this issue](https://github.com/Rerumu/Wasynth/issues/22). 

A few questions that came up when writing this:
1. The source of the operators, wasmparser, seems to have some fields listed in the structs, but others are missing. For example, their struct for `MemoryCopy` [only has the `src` and `dst` fields](https://github.com/bytecodealliance/wasm-tools/blob/e7bb0a86e440ab42fc3f08c5ed945da835ea6995/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs#L1283-L1284), whereas [there is also a third parameter according to the spec](https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-copy), the amount of memory to copy `n`. I assumed that this was popped off the stack explicitly - I have no idea why it's like this. `MemoryFill` is even weirder, only containing one field in the struct, `mem` and having two more in the spec, `value` and `len`. Any context on this? 

2. Why are the parameters not listed in wasmparser `Box<Expression>` rather than `u32`, which I'm pretty sure they are according to the spec? Why are they visited in `visit.rs`?

3. How do I test this? I try running `cargo test` but that seems to have a ton of failures. Not sure if it's like that normally. I inspected some of the generated files and I see code which looks approximately right but the tests still fail unfortunately. Not sure if there is a way that people usually manually test this. 

Thanks for your help in taking a look at this!