### PR TITLE
Avoid using luau specific extension in runtime.lua

### DIFF
--- a/codegen/luau/runtime/runtime.lua
+++ b/codegen/luau/runtime/runtime.lua
@@ -909,7 +909,9 @@ do
 	end
 
 	function store.string(memory, addr, data, len)
-		len = if len then len else #data
+		if not len then
+			len = #data
+		end
 
 		local rem = len % 4
 


### PR DESCRIPTION
This would avoid runtime issue for luau on luajit, though there are other issues too.