### PR TITLE
Export runtime for luau.

### DIFF
--- a/codegen/luau/src/translator.rs
+++ b/codegen/luau/src/translator.rs
@@ -97,6 +97,7 @@ fn write_import_list(list: &[Import], w: &mut dyn Write) -> Result<()> {
 }
 
 fn write_export_list(list: &[Export], w: &mut dyn Write) -> Result<()> {
+	writeln!(w, "\t\trt = rt,")?;
 	write_export_of(list, External::Func, w)?;
 	write_export_of(list, External::Table, w)?;
 	write_export_of(list, External::Memory, w)?;


### PR DESCRIPTION
Methods like `rt.load.string` on the runtime are super useful for implementing imported functions like the ones needed for WASI.  Exporting these functions from the generated code allows those functions to continue to work even as the memory representation changes (i.e. as it has from tables to buffers).