### PR TITLE
Faster luau runtime

### DIFF
--- a/codegen/luau/runtime/numeric_v3.lua
+++ b/codegen/luau/runtime/numeric_v3.lua
@@ -20,7 +20,7 @@ local bit_replace = bit32.replace
 local from_u32, from_u64, into_u64
 local num_subtract, num_divide_unsigned, num_negate
 local num_or, num_shift_left, num_shift_right_unsigned
-local num_is_negative, num_is_zero, num_is_less_unsigned
+local num_is_less_unsigned
 
 -- X: a[0 ..21]
 -- Y: a[22..31]
@@ -34,6 +34,10 @@ function Numeric.from_u32(data_1, data_2)
 	local z = bit_replace(bit_rshift(data_1, 22), bit_rshift(data_2, 22), 10, 10)
 
 	return constructor(x, y, z)
+end
+
+local function num_is_zero(value)
+	return value == NUM_ZERO
 end
 
 local function load_d1(value)
@@ -178,6 +182,10 @@ function Numeric.divide_unsigned(lhs, rhs)
 	end
 
 	return quotient, remainder
+end
+
+local function num_is_negative(value)
+	return value.Z >= 0x80000
 end
 
 function Numeric.divide_signed(lhs, rhs)
@@ -336,14 +344,6 @@ function Numeric.rotate_right(lhs, rhs)
 	end
 end
 
-function Numeric.is_negative(value)
-	return value.Z >= 0x80000
-end
-
-function Numeric.is_zero(value)
-	return value == NUM_ZERO
-end
-
 function Numeric.is_equal(lhs, rhs)
 	return lhs == rhs
 end
@@ -400,8 +400,8 @@ num_or = Numeric.bit_or
 num_shift_left = Numeric.shift_left
 num_shift_right_unsigned = Numeric.shift_right_unsigned
 
-num_is_negative = Numeric.is_negative
-num_is_zero = Numeric.is_zero
+Numeric.is_negative = num_is_negative
+Numeric.is_zero = num_is_zero
 num_is_less_unsigned = Numeric.is_less_unsigned
 
 NUM_ONE = from_u64(1)

--- a/codegen/luau/runtime/numeric_v3.lua
+++ b/codegen/luau/runtime/numeric_v3.lua
@@ -1,6 +1,8 @@
 local Numeric = {}
 
-local NUM_ZERO, NUM_ONE, NUM_SIX_FOUR
+local NUM_ZERO = Vector3.zero
+local NUM_ONE, NUM_SIX_FOUR
+
 local NUM_BIT_26, NUM_BIT_52
 
 local bit_lshift = bit32.lshift
@@ -339,11 +341,11 @@ function Numeric.is_negative(value)
 end
 
 function Numeric.is_zero(value)
-	return value.X == 0 and value.Y == 0 and value.Z == 0
+	return value == NUM_ZERO
 end
 
 function Numeric.is_equal(lhs, rhs)
-	return lhs.X == rhs.X and lhs.Y == rhs.Y and lhs.Z == rhs.Z
+	return lhs == rhs
 end
 
 function Numeric.is_less_unsigned(lhs, rhs)
@@ -402,7 +404,6 @@ num_is_negative = Numeric.is_negative
 num_is_zero = Numeric.is_zero
 num_is_less_unsigned = Numeric.is_less_unsigned
 
-NUM_ZERO = from_u64(0)
 NUM_ONE = from_u64(1)
 NUM_SIX_FOUR = from_u64(64)
 NUM_BIT_26 = from_u64(0x4000000)

--- a/codegen/luau/runtime/numeric_v3.lua
+++ b/codegen/luau/runtime/numeric_v3.lua
@@ -49,7 +49,8 @@ local function load_d2(value)
 end
 
 local function into_u32(value)
-	return load_d1(value), load_d2(value)
+	local x, y, z = value.X, value.Y, value.Z
+	return bit_replace(bit_and(x, 0x3FFFFF), z, 22, 10), bit_replace(bit_and(y, 0x3FFFFF), bit_rshift(z, 10), 22, 10)
 end
 Numeric.into_u32 = into_u32
 

--- a/codegen/luau/runtime/runtime.lua
+++ b/codegen/luau/runtime/runtime.lua
@@ -1,6 +1,7 @@
 local module = {}
 
 local bit_and = bit32.band
+local bit_or = bit32.bor
 local bit_xor = bit32.bxor
 local bit_lshift = bit32.lshift
 local bit_rshift = bit32.rshift
@@ -44,16 +45,16 @@ do
 	local num_divide_unsigned = Integer.divide_unsigned
 
 	function add.i32(lhs, rhs)
-		return bit_and(lhs + rhs, 0xFFFFFFFF)
+		return bit_or(lhs + rhs, 0)
 	end
 
 	function sub.i32(lhs, rhs)
-		return bit_and(lhs - rhs, 0xFFFFFFFF)
+		return bit_or(lhs - rhs, 0)
 	end
 
 	function mul.i32(lhs, rhs)
 		if (lhs + rhs) < 0x8000000 then
-			return bit_and(lhs * rhs, 0xFFFFFFFF)
+			return bit_or(lhs * rhs, 0)
 		else
 			local a16 = bit_rshift(lhs, 16)
 			local a00 = bit_and(lhs, 0xFFFF)
@@ -63,7 +64,7 @@ do
 			local c00 = a00 * b00
 			local c16 = a16 * b00 + a00 * b16
 
-			return bit_and(c00 + bit_lshift(c16, 16), 0xFFFFFFFF)
+			return bit_or(c00 + bit_lshift(c16, 16), 0)
 		end
 	end
 
@@ -73,13 +74,13 @@ do
 		lhs = to_i32(lhs)
 		rhs = to_i32(rhs)
 
-		return bit_and(math_modf(lhs / rhs), 0xFFFFFFFF)
+		return bit_or(math_modf(lhs / rhs), 0)
 	end
 
 	function div.u32(lhs, rhs)
 		assert(rhs ~= 0, "division by zero")
 
-		return bit_and(math_modf(lhs / rhs), 0xFFFFFFFF)
+		return bit_or(math_modf(lhs / rhs), 0)
 	end
 
 	function rem.i32(lhs, rhs)
@@ -88,7 +89,7 @@ do
 		lhs = to_i32(lhs)
 		rhs = to_i32(rhs)
 
-		return bit_and(math_fmod(lhs, rhs), 0xFFFFFFFF)
+		return bit_or(math_fmod(lhs, rhs), 0)
 	end
 
 	add.i64 = Integer.add
@@ -395,7 +396,7 @@ do
 	end
 
 	function truncate.i32_f32(num)
-		return bit_and(truncate_f64(num), 0xFFFFFFFF)
+		return bit_or(truncate_f64(num), 0)
 	end
 
 	truncate.i32_f64 = truncate.i32_f32
@@ -431,7 +432,7 @@ do
 	function saturate.i32_f32(num)
 		local temp = math_clamp(truncate_f64(num), -0x80000000, 0x7FFFFFFF)
 
-		return bit_and(temp, 0xFFFFFFFF)
+		return bit_or(temp, 0)
 	end
 
 	saturate.i32_f64 = saturate.i32_f32
@@ -474,7 +475,7 @@ do
 		num = bit_and(num, 0xFF)
 
 		if num >= 0x80 then
-			return bit_and(num - 0x100, 0xFFFFFFFF)
+			return bit_or(num - 0x100, 0)
 		else
 			return num
 		end
@@ -484,7 +485,7 @@ do
 		num = bit_and(num, 0xFFFF)
 
 		if num >= 0x8000 then
-			return bit_and(num - 0x10000, 0xFFFFFFFF)
+			return bit_or(num - 0x10000, 0)
 		else
 			return num
 		end
@@ -648,7 +649,7 @@ do
 	local buffer_write_f64 = buffer.writef64
 
 	function load.i32_i8(memory, addr)
-		return bit_and(buffer_read_i8(memory.data, addr), 0xFFFFFFFF)
+		return bit_or(buffer_read_i8(memory.data, addr), 0)
 	end
 
 	function load.i32_u8(memory, addr)
@@ -656,7 +657,7 @@ do
 	end
 
 	function load.i32_i16(memory, addr)
-		return bit_and(buffer_read_i16(memory.data, addr), 0xFFFFFFFF)
+		return bit_or(buffer_read_i16(memory.data, addr), 0)
 	end
 
 	function load.i32_u16(memory, addr)

--- a/codegen/luau/runtime/runtime.lua
+++ b/codegen/luau/runtime/runtime.lua
@@ -182,12 +182,12 @@ do
 	local bit_countrz = bit32.countrz
 
 	local function popcnt_i32(num)
-        num = bit_and(num, 0x55555555) + bit_and(bit_rshift(num, 1),  0x55555555)
-        num = bit_and(num, 0x33333333) + bit_and(bit_rshift(num, 2),  0x33333333)
-        num = bit_and(num, 0x0f0f0f0f) + bit_and(bit_rshift(num, 4),  0x0f0f0f0f)
-        num = bit_and(num, 0x00ff00ff) + bit_and(bit_rshift(num, 8),  0x00ff00ff)
-        num = bit_and(num, 0x0000ffff) + bit_and(bit_rshift(num, 16), 0x0000ffff)
-		return num
+		num = num - bit_and(bit_rshift(num, 1), 0x55555555)
+		num = bit_and(num, 0x33333333) + bit_and(bit_rshift(num, 2), 0x33333333)
+		num = bit_and((num + bit_rshift(num, 4)), 0x0F0F0F0F)
+		num = num + bit_rshift(num, 8)
+		num = num + bit_rshift(num, 16)
+		return bit_and(num, 0x0000003F)
 	end
 
 	popcnt.i32 = popcnt_i32

--- a/codegen/luau/runtime/runtime.lua
+++ b/codegen/luau/runtime/runtime.lua
@@ -182,14 +182,12 @@ do
 	local bit_countrz = bit32.countrz
 
 	local function popcnt_i32(num)
-		local count = 0
-
-		while num ~= 0 do
-			num = bit_and(num, num - 1)
-			count = count + 1
-		end
-
-		return count
+        num = bit_and(num, 0x55555555) + bit_and(bit_rshift(num, 1),  0x55555555)
+        num = bit_and(num, 0x33333333) + bit_and(bit_rshift(num, 2),  0x33333333)
+        num = bit_and(num, 0x0f0f0f0f) + bit_and(bit_rshift(num, 4),  0x0f0f0f0f)
+        num = bit_and(num, 0x00ff00ff) + bit_and(bit_rshift(num, 8),  0x00ff00ff)
+        num = bit_and(num, 0x0000ffff) + bit_and(bit_rshift(num, 16), 0x0000ffff)
+		return num
 	end
 
 	popcnt.i32 = popcnt_i32

--- a/codegen/luau/src/bin/wasm2luau.rs
+++ b/codegen/luau/src/bin/wasm2luau.rs
@@ -20,6 +20,7 @@ fn do_runtime(lock: &mut dyn Write) -> Result<()> {
 	let runtime = codegen_luau::RUNTIME;
 	let numeric = codegen_luau::NUMERIC;
 
+	writeln!(lock, "--!optimize 2")?;
 	writeln!(lock, "local Integer = (function()")?;
 	writeln!(lock, "{numeric}")?;
 	writeln!(lock, "end)()")?;


### PR DESCRIPTION
- Check vector equality with `a == b` instead of `a.X == b.X and a.Y == b.Y and a.Z == b.Z`
- Replace `load_d1(x), load_d2(x)` with `into_u32(x)`
- Branchless popcnt_i32
- Truncate with bor(x, 0) instead of band(x, 0xFFFFFFFF)
- Reorder function assignments
```
function TABLE.FUNCTION() ... end
local f = TABLE.FUNCTION
```
```
local function f() ... end
TABLE.FUNCTION = f
```

- Add `--!optimize 2` comment directive automatically